### PR TITLE
Clarify build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This extension provides support for [Declarative Gradle](https://github.com/grad
 
 There are two ways to install the extension
 
-1.  Use the repository itself. Check out the code, open it up in VSCode, and launch the `Extension` run configuration.
+1.  Use the repository itself. Check out the code, open it up in VSCode, run `npm install`, and launch the `Extension` run configuration.
 1.  Install the extension from the VSIX artifact created by the [CI pipeline](https://github.com/gradle/declarative-vscode-extension/actions/workflows/build.yml)
 
 ### Configuration


### PR DESCRIPTION
A tiny PR that simply clarifies that it is necessary to run `npm install`.